### PR TITLE
Adding über-security-minded state IDs

### DIFF
--- a/lib/Starch.pm
+++ b/lib/Starch.pm
@@ -36,7 +36,7 @@ Starch - Implementation independent persistent statefulness.
             class   => '::Memory',
         },
     ); # Returns a Starch::Manager object.
-    
+
     my $new_state = $starch->state();
     my $existing_state = $starch->state( $id );
 
@@ -62,6 +62,10 @@ Arthur Axel "fREW" Schmidt <frioux+cpanE<64>gmail.com>
 =item *
 
 Jonathan Scott Duff <duffE<64>pobox.com>
+
+=item *
+
+Sterling Hanenkamp <hanenkampE<64>cpan.org>
 
 =back
 

--- a/lib/Starch/Plugin/SecureStateID.pm
+++ b/lib/Starch/Plugin/SecureStateID.pm
@@ -1,0 +1,75 @@
+package Starch::Plugin::SecureStateID;
+
+use Math::Random::Secure ();
+use Digest::SHA ();
+use Scalar::Util qw( refaddr );
+use Types::Standard -types;
+
+use Moo::Role;
+use strictures 2;
+use namespace::clean;
+
+with qw(
+    Starch::Plugin::ForManager
+);
+
+has secure_state_id_sha => (
+    is          => 'ro',
+    isa         => Enum[1, 224, 256, 384, 512, 512224, 512256],
+    default     => 256,
+);
+
+sub _secure_state_id_sha {
+    my $self = shift;
+    Digest::SHA->new($self->secure_state_id_sha);
+}
+
+my $counter = 0;
+around state_id_seed => sub {
+    shift; # we never call the original
+    my ($self) = @_;
+    return join( '', ++$counter, time, Math::Random::Secure::rand(), $$, {}, refaddr($self) )
+};
+
+around generate_state_id => sub {
+    shift; # we never call the original
+    my ($self) = @_;
+    my $sha = $self->_secure_state_id_sha;
+    $sha->add( $self->state_id_seed() );
+    return $sha->hexdigest();
+};
+
+1;
+__END__
+
+=head1 NAME
+
+Starch::Plugin::SecureStateID - use cryptographically secure random when making state IDs
+
+=head1 SYNOPSIS
+
+    my $starch = Starch->new(
+        plugins             => ['::SecureStateID'],
+        secure_state_id_sha => 256,
+    );
+
+=head1 DESCRIPTION
+
+For each state stored in Starch, the generated ID is virtually guaranteed to be unique. It is not generated to be unguessable. By using this plugin, the state will include a random number generated using L<Math::Random::Secure> to assure that is both unique and includes a cryptographically secure random number in the calculated ID.
+
+This plugin also selects upgrades the state ID so that it is calculated using SHA-256 instead of SHA-1. SHA-1 hashed values are potentially guessable for attackers with a large enough budget. A possible downside is that SHA-256 creates a key that is 256 bits long, which results in an ID string that is 64 bytes long, rather than the 40 byte long string provided by SHA-1. The version of SHA used may be chosen with the L</secure_state_id_sha> option.
+
+=head1 OPTIONAL MANAGER ARGUMENTS
+
+These arguments are added to the L<Starch::Manager> class.
+
+=head2 secure_state_id_sha
+
+This names the SHA algorithm to use. It may be set to one of: 1, 224, 256, 284, 512224, and 512256. The default is 256 (though, if you do not use this plugin, SHA-1 will be used).
+
+=head1 AUTHORS AND LICENSE
+
+See L<Starch/AUTHOR>, L<Starch/CONTRIBUTORS>, and L<Starch/LICENSE>.
+
+=cut
+

--- a/t/plugin_secure_state.t
+++ b/t/plugin_secure_state.t
@@ -1,0 +1,44 @@
+#!/usr/bin/env perl
+#use strictures 2;
+
+use Test::More;
+use Starch;
+
+eval "use Math::Random::Secure;";
+plan skip_all => "Math::Random::Secure is not installed."
+    if $@;
+
+my $secure_rand_called = 0;
+{
+    no warnings 'redefine';
+    my $original_random = \&Math::Random::Secure::rand;
+    *Math::Random::Secure::rand = sub (;$) {
+        $secure_rand_called++;
+        return $original_random->();
+    };
+}
+
+subtest default_options => sub {
+    my $starch = Starch->new(
+        plugins => ['::SecureStateID'],
+        store   => { class => '::Memory' },
+    );
+
+    my $state = $starch->state();
+    is length $state->id, 64, 'SHA-256 used for state id';
+    is $secure_rand_called, 1, 'Math::Random::Secure::rand was used';
+};
+
+subtest sha512_used => sub {
+    my $starch = Starch->new(
+        plugins             => ['::SecureStateID'],
+        store               => { class => '::Memory' },
+        secure_state_id_sha => 512,
+    );
+
+    my $state = $starch->state();
+    is length $state->id, 128, 'SHA-512 used for state id';
+    is $secure_rand_called, 2, 'Math::Random::Secure::rand was used';
+};
+
+done_testing;


### PR DESCRIPTION
The existing IDs would be difficult/expensive to predict. The defaults when
using ::SecureStateID should be much more difficult/expensive.